### PR TITLE
Tiger & Eagle Level Complete

### DIFF
--- a/db/migrate/201205091500_create_recipes.rb
+++ b/db/migrate/201205091500_create_recipes.rb
@@ -1,0 +1,14 @@
+class CreateRecipes < ActiveRecord::Migration
+  def change
+    create_table :recipes do |t|
+      t.string :name
+      t.timestamps
+    end
+    
+    create_table :ingredients do |t|
+      t.string :name
+      t.references :recipe # Cool! I learnt that this creates :ingriedient_id for you!
+      t.timestamps
+    end
+  end
+end

--- a/db/seed.rb
+++ b/db/seed.rb
@@ -4,4 +4,9 @@ Show.delete_all
 amc = Network.create(name: "AMC")
 nbc = Network.create(name: "NBC")
 Show.create(name: "Mad Men", day_of_week: "Sunday", hour_of_day: 22, network: amc)
-Show.create(name: "Community", day_of_week: "Thursday", hour_of_day: 20, network: nbc)
+Show.create(name: "Community", day_of_week: "Thursday", hour_of_day: 19, network: nbc)
+Show.create(name: "How I met your Mother", day_of_week: "Sunday", hour_of_day: 21, network: amc)
+Show.create(name: "Modern Familiy", day_of_week: "Wednesday", hour_of_day: 23, network: nbc)
+Show.create(name: "Two and a Half Men", day_of_week: "Tuesday", hour_of_day: 22, network: amc)
+Show.create(name: "Friends", day_of_week: "Monday", hour_of_day: 12, network: nbc)
+

--- a/db/seed.rb
+++ b/db/seed.rb
@@ -1,4 +1,4 @@
-# Cleaning Out
+# Cleaning Out$1}$2
 Network.delete_all
 Show.delete_all
 amc = Network.create(name: "AMC")
@@ -10,3 +10,15 @@ Show.create(name: "Modern Familiy", day_of_week: "Wednesday", hour_of_day: 23, n
 Show.create(name: "Two and a Half Men", day_of_week: "Tuesday", hour_of_day: 22, network: amc)
 Show.create(name: "Friends", day_of_week: "Monday", hour_of_day: 12, network: nbc)
 
+# My recipe seeds
+
+Recipe.delete_all
+Ingredient.delete_all
+cornbread_muffins = Recipe.create(name: "cornbread muffins")
+tacos = Recipe.create(name: "tacos")
+Ingredient.create(name: 'corn', recipe: cornbread_muffins)
+Ingredient.create(name: 'butter', recipe: cornbread_muffins)
+Ingredient.create(name: 'oil', recipe: cornbread_muffins)
+Ingredient.create(name: 'tortilla', recipe: tacos)
+Ingredient.create(name: 'avocado', recipe: tacos)
+Ingredient.create(name: 'shrimp', recipe: tacos)

--- a/db/setup.rb
+++ b/db/setup.rb
@@ -7,9 +7,10 @@ connection_details = YAML::load(File.open('config/database.yml'))
 
 
 # Setup out connection details
-ActiveRecord::Base.establish_connection(connection_details.merge({database: 'postgres', schema_search_path: 'public'}))
+ActiveRecord::Base.establish_connection(connection_details.merge({'database' => 'postgres', 'schema_search_path' => 'public'}))
 # create the 'tv' database 
-ActiveRecord::Base.connection.create_database(connection_details.fetch(:database)) rescue nil
+ActiveRecord::Base.connection.drop_database(connection_details.fetch('database')) rescue nil
+ActiveRecord::Base.connection.create_database(connection_details.fetch('database')) rescue nil 
 # connect to it
 ActiveRecord::Base.establish_connection(connection_details)
 # Migrate all the things

--- a/models/ingredient.rb
+++ b/models/ingredient.rb
@@ -1,0 +1,9 @@
+class Ingredient < ActiveRecord::Base
+  belongs_to :recipe
+  
+  validates :name, presence: true
+    
+  def to_s
+    name
+  end
+end

--- a/models/recipe.rb
+++ b/models/recipe.rb
@@ -1,0 +1,11 @@
+class Recipe < ActiveRecord::Base
+  
+  has_many :ingredients
+  
+  validates :name, presence: true
+  
+  def to_s
+    name
+  end
+
+end

--- a/models/show.rb
+++ b/models/show.rb
@@ -4,6 +4,6 @@ class Show < ActiveRecord::Base
 	validates_presence_of :name
 
 	def to_s
-		"#{name} airs at #{hour_of_day}:#{day_of_week}:00 on #{network} "
+		"#{name} airs at #{hour_of_day}:00 every #{day_of_week} on #{network}."
 	end
 end

--- a/watchman.rb
+++ b/watchman.rb
@@ -6,10 +6,21 @@ Dir.glob('./models/*').each { |r| require r}
 require "./db/seed"
 
 puts "There are #{Show.count} in the database"
+puts
+puts "What day do you want to watch shows?"
+puts 
+print '~>'
+day = gets.chomp.capitalize
 
 Network.all.each do |network|
-	puts "Shows airing on #{network}"
-	network.shows.each do |show|
-		puts show
-	end	
+  network.shows.where(day_of_week: day).each do |show|
+    puts show
+  end
 end
+
+# Network.all.each do |network|
+#   puts "Shows airing on #{network}"
+#   network.shows.each do |show|
+#     puts show
+#   end 
+# end

--- a/watchman.rb
+++ b/watchman.rb
@@ -18,9 +18,22 @@ Network.all.each do |network|
   end
 end
 
-# Network.all.each do |network|
-#   puts "Shows airing on #{network}"
-#   network.shows.each do |show|
-#     puts show
-#   end 
-# end
+puts "Cool, now I also enjoy cooking and have some great recipes."
+puts "Enter a recipe below e.g. 'Cornbread Muffins' or 'Tacos' and I'll dish out the ingredients"
+puts
+print '~>'
+input = gets.chomp.downcase
+
+recipe = Recipe.where(name: input)
+while recipe.empty?
+  puts "Sorry, I can't do that right now. Please try again"
+  print "~>"
+  input = gets.chomp.downcase
+  recipe = Recipe.where(name: input)
+end
+
+puts "The ingredients for %s are:" % recipe
+
+Recipe.where(name: input).first.ingredients.each do |ingredient|
+  puts ingredient
+end


### PR DESCRIPTION
Q: In Rails, migrations are smart enough to not run if they have already been migrated. Whereas in our example the migrations always run when I load `ruby watchman.rb`. 

Is there some other Rails magic going on here in addition to your `ActiveRecord::Migrator.migrate("db/migrate/")` line of code?
